### PR TITLE
Added an option to support spaces in tags.

### DIFF
--- a/AutoShutdownSchedule.ps1
+++ b/AutoShutdownSchedule.ps1
@@ -489,7 +489,7 @@ try {
             continue
         }
 
-        $Result = ValidateScheduleList $schedule
+        $Result = ValidateScheduleList $($schedule -replace '\s','')
         if ($Result -ne 'OK') {
             Write-Error "[$($vm.Name)]: $Result. Skipping this VM."
             continue


### PR DESCRIPTION
I have added a piece of code that removes the spaces in the tags and therefore allows them to be configured as :  18:00 -> 20:00

In my case different projects are created with both formats (by different teams).

I think this can be of interest to several users of the script. 😃 